### PR TITLE
feat: DarkMode 로 변경되면서 TabBar 와 SegmentPicker 색상을 시스템 색상으로 수정했습니다.

### DIFF
--- a/EmojiDiary/EmojiDiary/ListView/ListView.swift
+++ b/EmojiDiary/EmojiDiary/ListView/ListView.swift
@@ -176,7 +176,6 @@ struct ListView: View {
                 })
                 
                 .pickerStyle(.segmented)
-                .background(.white)
             }
             
             ScrollViewReader { proxy in
@@ -217,7 +216,6 @@ struct ListView: View {
                 .safeAreaInset(edge: .bottom, content: {
                     Divider()
                         .frame(height: 0.5)
-                        .background(Color(.white))
                 })
                 .onChange(of: selectedTab) { _ in
                     withAnimation {


### PR DESCRIPTION
## 🤔 배경
<!--
> PR을 하게 된 문제상황, 배경 등 개요에 대해서 작성해주세요!
-->
화면 모드를 라이트 모드에서 다크 모드로 변경할 때, SegmentPicker와 SafeAreaTabBar의 .white 색상으로 변경되는 것을 수정했습니다. 

## 📃 작업 내역
<!--
> PR에서 한 작업을 작성해주새요!
> e.g. - 첫번째 작업
-->
화면 모드를 라이트 모드에서 다크 모드로 변경할 때, SegmentPicker와 SafeAreaTabBar의 .white 색상 코드를 제거했습니다. 

## ✅ 리뷰 노트
<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 이 부분은 불변성을 띄도록 하기 위해 struct를 사용했어요!
-->

## 🎨 스크린샷
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-16 at 14 20 23" src="https://github.com/user-attachments/assets/3fa65635-f081-4d98-9f92-ae7a0ea43cac" />
